### PR TITLE
Admin#project-v12: fix broken hyperlink subaddress

### DIFF
--- a/admin/project-v12.md
+++ b/admin/project-v12.md
@@ -64,7 +64,7 @@ Also note <trigger trigger="click" for="modal:v12-testingExpectations">our expec
     * Why it is implemented that way.
     * Alternatives considered.
   * The stated objective is to explain the implementation to a future developer, but a hidden objective is to show evidence that you can document deeply-technical content using prose, examples, diagrams, code snippets, etc. appropriately. To that end, you may also describe features that you plan to implement in the future, even beyond v1.5 (hypothetically).
-  * For an example, see [the description of the undo/redo feature implementation in the AddressBook-Level4 developer guide](https://nus-cs2103-ay1718s2.github.io/addressbook-level4/DeveloperGuide.html#undo-redo-mechanism).
+  * For an example, see [the description of the undo/redo feature implementation in the AddressBook-Level4 developer guide](https://nus-cs2103-ay1718s2.github.io/addressbook-level4/DeveloperGuide.html#undo-redo-feature).
   
 
 ### v1.2 Demo

--- a/site.json
+++ b/site.json
@@ -533,10 +533,6 @@
       "title": "CS2103/T Textbook - Software Design Principles: Open-Closed Principle"
     },
     {
-      "src": "book/principles/openClosedPrinciple/index.md",
-      "title": "CS2103/T Textbook - Software Design Principles: Open-Closed Principle: What"
-    },
-    {
       "src": "book/principles/solidPrinciples/index.md",
       "title": "CS2103/T Textbook - Principles: SOLID Principles"
     },


### PR DESCRIPTION
The hyperlink sub-address that directs to undo/redo feature
implementation, in the AddressBook-Level4 developer guide, is broken.

Let's fix it by replacing the sub-address, #undo-redo-mechanism, with
#undo-redo-feature.